### PR TITLE
add -check tc flag; dynamically find sac2c SO

### DIFF
--- a/kernel.py
+++ b/kernel.py
@@ -104,7 +104,7 @@ class SacKernel(Kernel):
         ]
         self.funs = dict()
                 # Make sure to do checks on array bounds as well
-        self.sac2c_flags =  ['-v0', '-O0', '-noprelude', '-noinl', '-specmode', 'akd', '-check', 'tc']
+        self.sac2c_flags =  ['-v0', '-O0', '-noprelude', '-noinl', '-specmode', 'aud', '-check', 'c']
 
         # get sac2c_p binary
         os.environ["PATH"] += "/usr/local/bin"
@@ -220,7 +220,7 @@ Currently the following commands are available:
         imports = "\n".join (self.imports)
 
         if r == 1: # expr
-            stmts += "StdIO::print ({}\n\n);".format (txt)
+            stmts += "\nStdIO::print ({}\n\n);\n".format (txt)
 
         elif r == 2: # stmt
             stmts += txt

--- a/kernel.py
+++ b/kernel.py
@@ -109,17 +109,20 @@ class SacKernel(Kernel):
         # get sac2c_p binary
         os.environ["PATH"] += "/usr/local/bin"
         self.sac2c_bin = shutil.which ('sac2c_p')
+        if not self.sac2c_bin:
+            raise RuntimeError ("Unable to find sac2c_p binary!")
 
         # find global lib directory (different depending on sac2c version)
         sac_path_proc = subprocess.run ([self.sac2c_bin, "-C", "TREE_OUTPUTDIR"], capture_output=True, text=True)
+        sac_lib_path = sac_path_proc.stdout.split(":")[0].strip()
         if "LD_LIBRARY_PATH" in os.environ:
-            os.environ["LD_LIBRARY_PATH"] += sac_path_proc.stdout.split(":")[0].strip()
+            os.environ["LD_LIBRARY_PATH"] += sac_lib_path
         else:
-            os.environ["LD_LIBRARY_PATH"] = sac_path_proc.stdout.split(":")[0].strip()
+            os.environ["LD_LIBRARY_PATH"] = sac_lib_path
         sac2c_so_name = find_library ('sac2c_p')
         if not sac2c_so_name:
             raise RuntimeError ("Unable to load sac2c_p shared library!")
-        self.sac2c_so = path.join (sac_path_proc.stdout.split(":")[0].strip(), sac2c_so_name)
+        self.sac2c_so = path.join (sac_lib_path, sac2c_so_name)
 
         # get shared object
         self.sac2c_so_handle = ctypes.CDLL (self.sac2c_so, mode=(1|ctypes.RTLD_GLOBAL))


### PR DESCRIPTION
With this PR we add `-check tc` flag which activates some runtime checks on array bounds and indices.

Additionally, we revamp how sac2c is detected and loaded (current mechanism work only for global installs of sac2c).

Should resolve #5.

EDIT: we also resolve #4.