### PR TITLE
set -maxspec 0 for now

### DIFF
--- a/kernel.py
+++ b/kernel.py
@@ -417,7 +417,7 @@ class SacKernel(Kernel):
         self.binary = None
         self.sac_check = None
         # Make sure to do checks on array bounds as well
-        self.sac2c_flags =  ['-v0', '-O0', '-noprelude', '-noinl', '-specmode', 'akd', '-check', 'tc']
+        self.sac2c_flags =  ['-v0', '-O0', '-noprelude', '-noinl', '-maxspec', '0', '-check', 'tc']
 
         # get sac2c_p binary
         os.environ["PATH"] += "/usr/local/bin"

--- a/kernel.py
+++ b/kernel.py
@@ -417,7 +417,7 @@ class SacKernel(Kernel):
         self.binary = None
         self.sac_check = None
         # Make sure to do checks on array bounds as well
-        self.sac2c_flags =  ['-v0', '-O0', '-noprelude', '-noinl', '-specmode', 'akd', '-check', 't']
+        self.sac2c_flags =  ['-v0', '-O0', '-noprelude', '-noinl', '-maxspec', '0', '-check', 'tc']
 
         # get sac2c_p binary
         os.environ["PATH"] += "/usr/local/bin"

--- a/kernel.py
+++ b/kernel.py
@@ -417,7 +417,7 @@ class SacKernel(Kernel):
         self.binary = None
         self.sac_check = None
         # Make sure to do checks on array bounds as well
-        self.sac2c_flags =  ['-v0', '-O0', '-noprelude', '-noinl', '-maxspec', '0', '-check', 'tc']
+        self.sac2c_flags =  ['-v0', '-O0', '-noprelude', '-noinl', '-specmode', 'akd', '-check', 't']
 
         # get sac2c_p binary
         os.environ["PATH"] += "/usr/local/bin"


### PR DESCRIPTION
Specialization is broken when using type patterns, likely has to do with the guards.

```
int[n:shp,n] my_iota(int[n] shp)
{
    return { iv -> iv | iv < shp };
}
```

For now we can avoid this by setting `-maxspec 0`